### PR TITLE
Fix wrong XML data values to pass PHPUnit tests

### DIFF
--- a/tests/fixtures/mod_adaptivequiz.xml
+++ b/tests/fixtures/mod_adaptivequiz.xml
@@ -45,7 +45,7 @@
         <column>id</column>
         <column>name</column>
         <row>
-            <value>50</value>
+            <value>1000</value>
             <value>adaptivequiz</value>
         </row>
     </table>
@@ -82,15 +82,22 @@
         <row>
             <value>5</value>
             <value>2</value>
-            <value>50</value>
-            <value>13</value>
+            <value>1000</value>
+            <value>1</value>
             <value>10</value>
         </row>
         <row>
             <value>6</value>
             <value>2</value>
-            <value>50</value>
-            <value>1</value>
+            <value>1000</value>
+            <value>13</value>
+            <value>10</value>
+        </row>
+        <row>
+            <value>7</value>
+            <value>2</value>
+            <value>1000</value>
+            <value>330</value>
             <value>10</value>
         </row>
     </table>

--- a/tests/fixtures/mod_adaptivequiz_adaptiveattempt.xml
+++ b/tests/fixtures/mod_adaptivequiz_adaptiveattempt.xml
@@ -25,7 +25,7 @@
         <column>id</column>
         <column>name</column>
         <row>
-            <value>50</value>
+            <value>1000</value>
             <value>adaptivequiz</value>
         </row>
     </table>
@@ -63,7 +63,7 @@
         <row>
             <value>5</value>
             <value>200</value>
-            <value>50</value>
+            <value>1000</value>
             <value>330</value>
             <value>10</value>
             <value>2</value>
@@ -284,7 +284,7 @@
             <value>1</value>
             <value>2</value>
         </row>
-    </table>   
+    </table>
     <table name="tag">
         <column>id</column>
         <column>userid</column>


### PR DESCRIPTION
This PR will fix an error and a risky warning that are thrown when running the PHPUnit tests:
1. Error in mod_adaptivequiz_adaptiveattempt.xml file: it throws an error for those sites that have more than 50 modules in their databases (this also applies for the second file).
2. Risky warning in mod_adaptivequiz.xml file: the first record in the _course_modules_ table was defined with a wrong number (13 instead of 1) in the field _instance_. I also added a new record for this table based on the number of records that were define in the _adaptivequiz_ table (3, not 2), so they are now in sync.