### PR TITLE
Display n-th instead of (n-1)th question in progressbar

### DIFF
--- a/classes/output/attempt_progress.php
+++ b/classes/output/attempt_progress.php
@@ -60,7 +60,7 @@ class attempt_progress implements renderable, templatable {
      * @param string|null $helpiconcontent
      */
     public function __construct(int $questionsanswered, int $maximumquestions, bool $showprogressbar, ?string $helpiconcontent) {
-        $this->questionsanswered = $questionsanswered;
+        $this->questionsanswered = $questionsanswered + 1;
         $this->maximumquestions = $maximumquestions;
         $this->showprogressbar = $showprogressbar;
         $this->helpiconcontent = $helpiconcontent;


### PR DESCRIPTION
We've got several complaints from our students that their tests aborded abruptly and unexpectedly when answering the (n-1)th out of n questions.

Turned out that they got confused by the numbers in the progressbar with display the numbers already answered instead of the number of the question with they currently working on. The fact is not comunicated clearly so we propose to display $numberofquestionsanswered + 1 to reduce unnecessary and unwanted cognitive disonance by the using interface when taking a test.